### PR TITLE
add reactive villains & reactive data service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -241,26 +241,6 @@
         "tslib": "1.9.0"
       }
     },
-    "@ngrx/effects": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/effects/-/effects-5.2.0.tgz",
-      "integrity": "sha1-qnYractv1GRNckoc7NJlyqQrrwk="
-    },
-    "@ngrx/entity": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/entity/-/entity-5.2.0.tgz",
-      "integrity": "sha1-aLkLMVm7RuxbLQ3j+gv06A6Uly0="
-    },
-    "@ngrx/store": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-5.2.0.tgz",
-      "integrity": "sha1-Yn7XTJzZVGKTBIXZEqVXEXsjkD4="
-    },
-    "@ngrx/store-devtools": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/store-devtools/-/store-devtools-5.2.0.tgz",
-      "integrity": "sha1-L/+RapqjSTdYJncrNZ27ZLnl1iI="
-    },
     "@ngtools/json-schema": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ngtools/json-schema/-/json-schema-1.2.0.tgz",
@@ -7231,11 +7211,6 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true,
       "optional": true
-    },
-    "ngrx-data": {
-      "version": "1.0.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/ngrx-data/-/ngrx-data-1.0.0-alpha.15.tgz",
-      "integrity": "sha512-YUyvCf6VEfOi2CdCv3QtVk7l/DYcKiBzC0YRkNljR9HJPMlKLpZWOH+nhnkMMAGxD0KdYgF3gIhpsn3uKnr/mw=="
     },
     "no-case": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "^5.2.8",
     "@angular/platform-browser-dynamic": "^5.2.8",
     "@angular/router": "^5.2.8",
-    "angular-in-memory-web-api": "^0.5.3",
+    "angular-in-memory-web-api": "^0.5.4",
     "body-parser": "^1.18.2",
     "core-js": "^2.5.3",
     "hammerjs": "^2.0.8",

--- a/src/app/core/index.ts
+++ b/src/app/core/index.ts
@@ -1,4 +1,5 @@
 export * from './core.module';
 export * from './in-memory-data.service';
 export * from './model';
+export * from './reactive-data.service';
 export * from './toast.service';

--- a/src/app/core/index.ts
+++ b/src/app/core/index.ts
@@ -1,5 +1,6 @@
 export * from './core.module';
 export * from './in-memory-data.service';
+export * from './master-detail-commands';
 export * from './model';
 export * from './reactive-data.service';
 export * from './toast.service';

--- a/src/app/core/master-detail-commands.ts
+++ b/src/app/core/master-detail-commands.ts
@@ -1,0 +1,7 @@
+export interface MasterDetailCommands<T> {
+  close: () => void;
+  add: (entity: T) => void;
+  delete: (entity: T) => void;
+  select: (entity: T) => void;
+  update: (entity: T) => void;
+}

--- a/src/app/core/reactive-data.service.ts
+++ b/src/app/core/reactive-data.service.ts
@@ -1,0 +1,117 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+
+import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Observable } from 'rxjs/Observable';
+import { map, tap } from 'rxjs/operators';
+
+import { ToastService } from '../core';
+
+const api = '/api';
+
+/**
+ * Base REST-like DataService in reactive style for entity of type T
+ */
+export abstract class ReactiveDataService<T extends {id: number | string}> {
+  protected entityResource: string;
+  protected collectionResource: string;
+
+  // cached entities
+  private entities: T[];
+  private entitiesSubject = new BehaviorSubject<T[]>([]);
+
+  /** Observable of cached entities */
+  protected entities$ = this.entitiesSubject.asObservable();
+
+  protected errorsSubject = new Subject<string>();
+
+  /** Observable of error messages */
+  errors$ = this.errorsSubject.asObservable();
+
+  protected loadingSubject = new BehaviorSubject(false);
+
+  /** Observable of flag indicating when the service is loading data from the server */
+  loading$ = this.loadingSubject.asObservable();
+
+  constructor(
+    protected entityName: string,
+    protected http: HttpClient,
+    protected toastService: ToastService,
+    protected entityNamePlural?: string
+  ) {
+    this.entityNamePlural = entityNamePlural || entityName + 's';
+    this.entityResource = this.entityName.toLowerCase();
+    this.collectionResource = this.entityNamePlural.toLowerCase();
+  }
+
+  getAll() {
+    this.loadingSubject.next(true);
+    this.http
+      .get<T[]>(`${api}/${this.collectionResource}`)
+      .subscribe(
+        entities => {
+          this.next(entities);
+          this.loadingSubject.next(false);
+          this.log(`${this.entityNamePlural} retrieved.`, 'GET');
+        },
+        this.handleError('Retrieval', 'GET')
+      );
+  }
+
+  delete(id: number | string) {
+    // delete optimistically
+    this.next(this.entities.filter(e => e.id !== id));
+
+    this.http.delete(`${api}/${this.entityResource}/${id}`)
+    .subscribe(
+      () => {
+        this.log(`${this.entityName} with id=${id} deleted.`, 'DELETE');
+      },
+      this.handleError('Delete', 'DELETE')
+    );
+  }
+
+  add(entity: T) {
+    this.http.post<T>(`${api}/${this.entityResource}/`, entity)
+    .subscribe(
+      addedEntity => {
+        this.next(this.entities.concat(addedEntity));
+        this.log(`${this.entityName} added.`, 'POST');
+      },
+      this.handleError('Add', 'POST')
+    );
+  }
+
+  update(entity: T) {
+    const id = entity.id;
+    this.http.put<T>(`${api}/${this.entityResource}/${id}`, entity)
+    .subscribe(
+      updatedEntity => {
+        this.next(this.entities.map(e => e.id === id ? (updatedEntity || entity) : e));
+        this.log(`${this.entityName} updated.`, 'PUT');
+      },
+      this.handleError('Update', 'PUT')
+    );
+  }
+
+  protected handleError(operation: string, method: string) {
+    return function errorHandler(res: HttpErrorResponse) {
+      console.error(res);
+      const eMsg = res.message || '';
+      const msg = `${this.entityNamePlural} ${operation} Error${eMsg ? ': ' + eMsg : ''}`;
+      this.log(msg, method);
+      this.errorsSubject.next(msg);
+      this.loadingSubject.next(false);
+    }.bind(this);
+  }
+
+  protected log(message: string, method: string) {
+    this.toastService.openSnackBar(message, method);
+  }
+
+  /** Set the cached entities and emit on the entities$ observable */
+  protected next(entities: T[]) {
+    this.entities = entities;
+    this.entitiesSubject.next(entities);
+  }
+}

--- a/src/app/core/toolbar/toolbar.component.html
+++ b/src/app/core/toolbar/toolbar.component.html
@@ -12,6 +12,9 @@
       <a mat-button [routerLink]="['/villains']" routerLinkActive="router-link-active">
         <span>Villains</span>
       </a>
+      <a mat-button [routerLink]="['/villains/reactive']" routerLinkActive="router-link-active">
+        <span>Reactive Villains</span>
+      </a>
     </div>
   </mat-toolbar-row>
   <mat-toolbar-row class="row-commands">

--- a/src/app/villains/villain-detail/villain-detail-reactive.component.ts
+++ b/src/app/villains/villain-detail/villain-detail-reactive.component.ts
@@ -9,19 +9,18 @@ import {
   SimpleChanges
 } from '@angular/core';
 
-import { Villain } from '../../core';
 import { Validators, FormBuilder, FormGroup } from '@angular/forms';
 
+import { MasterDetailCommands, Villain } from '../../core';
+
 @Component({
-  selector: 'app-villain-detail',
+  selector: 'app-villain-reactive-detail',
   templateUrl: './villain-detail.component.html',
   styleUrls: ['./villain-detail.component.scss']
 })
-export class VillainDetailComponent implements OnChanges {
+export class VillainReactiveDetailComponent implements OnChanges {
   @Input() villain: Villain;
-  @Output() unselect = new EventEmitter<string>();
-  @Output() add = new EventEmitter<Villain>();
-  @Output() update = new EventEmitter<Villain>();
+  @Input() commands: MasterDetailCommands<Villain>;
 
   @ViewChild('name') nameElement: ElementRef;
 
@@ -49,13 +48,13 @@ export class VillainDetailComponent implements OnChanges {
   addVillain(form: FormGroup) {
     const { value, valid, touched } = form;
     if (touched && valid) {
-      this.add.emit({ ...this.villain, ...value });
+      this.commands.add({ ...this.villain, ...value });
     }
     this.close();
   }
 
   close() {
-    this.unselect.emit();
+    this.commands.close();
   }
 
   saveVillain(form: FormGroup) {
@@ -73,7 +72,7 @@ export class VillainDetailComponent implements OnChanges {
   updateVillain(form: FormGroup) {
     const { value, valid, touched } = form;
     if (touched && valid) {
-      this.update.emit({ ...this.villain, ...value });
+      this.commands.update({ ...this.villain, ...value });
     }
     this.close();
   }

--- a/src/app/villains/villain-detail/villain-detail.component.html
+++ b/src/app/villains/villain-detail/villain-detail.component.html
@@ -21,7 +21,7 @@
           </mat-form-field>
         </div>
       </div>
-      <button mat-raised-button color="accent" type="button" (click)="clear()" matTooltip="Cancel all changes">Cancel</button>
+      <button mat-raised-button color="accent" type="button" (click)="close()" matTooltip="Cancel all changes">Cancel</button>
       <button mat-raised-button color="primary" type="button" (click)="saveVillain(form)" matTooltip="Save all changes">Save</button>
     </form>
   </mat-card-content>

--- a/src/app/villains/villain-list/villain-list-reactive.component.ts
+++ b/src/app/villains/villain-list/villain-list-reactive.component.ts
@@ -1,0 +1,26 @@
+import { Component, Input } from '@angular/core';
+
+import { MasterDetailCommands, Villain } from '../../core';
+
+@Component({
+  selector: 'app-villain-reactive-list',
+  templateUrl: './villain-list.component.html',
+  styleUrls: ['./villain-list.component.scss']
+})
+export class VillainReactiveListComponent {
+  @Input() villains: Villain[];
+  @Input() selectedVillain: Villain;
+  @Input() commands: MasterDetailCommands<Villain>;
+
+  byId(villain: Villain) {
+    return villain.id;
+  }
+
+  onSelect(villain: Villain) {
+    this.commands.select(villain);
+  }
+
+  deleteVillain(villain: Villain) {
+    this.commands.delete(villain);
+  }
+}

--- a/src/app/villains/villain-reactive.service.ts
+++ b/src/app/villains/villain-reactive.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { Villain, ToastService, ReactiveDataService } from '../core';
+
+@Injectable()
+export class VillainReactiveService extends ReactiveDataService<Villain> {
+  constructor(http: HttpClient, toastService: ToastService) {
+    super('Villain', http, toastService);
+  }
+
+  villains$ = this.entities$;
+}

--- a/src/app/villains/villains-routing.module.ts
+++ b/src/app/villains/villains-routing.module.ts
@@ -2,8 +2,12 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { VillainsComponent } from './villains/villains.component';
+import { VillainsReactiveComponent } from './villains/villains-reactive.component';
 
-const routes: Routes = [{ path: '', pathMatch: 'full', component: VillainsComponent }];
+const routes: Routes = [
+  { path: '', pathMatch: 'full', component: VillainsComponent },
+  { path: 'reactive', pathMatch: 'full', component: VillainsReactiveComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/src/app/villains/villains.module.ts
+++ b/src/app/villains/villains.module.ts
@@ -5,6 +5,10 @@ import { VillainsRoutingModule } from './villains-routing.module';
 import { VillainDetailComponent } from './villain-detail/villain-detail.component';
 import { VillainsComponent } from './villains/villains.component';
 import { VillainListComponent } from './villain-list/villain-list.component';
+
+import { VillainsReactiveComponent } from './villains/villains-reactive.component';
+import { VillainReactiveService } from './villain-reactive.service';
+
 import { VillainService } from './villain.service';
 import { SharedModule } from '../shared/shared.module';
 import { MaterialModule } from '../material/material.module';
@@ -14,9 +18,10 @@ import { MaterialModule } from '../material/material.module';
   exports: [VillainsComponent, VillainDetailComponent],
   declarations: [
     VillainsComponent,
+    VillainsReactiveComponent,
     VillainDetailComponent,
     VillainListComponent
   ],
-  providers: [VillainService]
+  providers: [VillainService, VillainReactiveService]
 })
 export class VillainsModule {}

--- a/src/app/villains/villains.module.ts
+++ b/src/app/villains/villains.module.ts
@@ -6,6 +6,8 @@ import { VillainDetailComponent } from './villain-detail/villain-detail.componen
 import { VillainsComponent } from './villains/villains.component';
 import { VillainListComponent } from './villain-list/villain-list.component';
 
+import { VillainReactiveDetailComponent } from './villain-detail/villain-detail-reactive.component';
+import { VillainReactiveListComponent } from './villain-list/villain-list-reactive.component';
 import { VillainsReactiveComponent } from './villains/villains-reactive.component';
 import { VillainReactiveService } from './villain-reactive.service';
 
@@ -17,10 +19,9 @@ import { MaterialModule } from '../material/material.module';
   imports: [CommonModule, SharedModule, MaterialModule, VillainsRoutingModule],
   exports: [VillainsComponent, VillainDetailComponent],
   declarations: [
-    VillainsComponent,
-    VillainsReactiveComponent,
-    VillainDetailComponent,
-    VillainListComponent
+    VillainsComponent, VillainsReactiveComponent,
+    VillainDetailComponent, VillainReactiveDetailComponent,
+    VillainListComponent, VillainReactiveListComponent
   ],
   providers: [VillainService, VillainReactiveService]
 })

--- a/src/app/villains/villains/villains-reactive.component.html
+++ b/src/app/villains/villains/villains-reactive.component.html
@@ -8,15 +8,14 @@
 <div class="content-container">
   <div class="list-container">
     <div *ngIf="villains$ | async as villains">
-      <mat-spinner *ngIf="loading$ | async ;else villainList" mode="indeterminate" color="accent"></mat-spinner>
+      <mat-spinner *ngIf="loading$ | async; else villainList" mode="indeterminate" color="accent"></mat-spinner>
       <ng-template #villainList>
-        <app-villain-list [villains]="villains" [selectedVillain]="selectedVillain" (deleted)="deleteVillain($event)" (selected)="onSelect($event)"></app-villain-list>
+        <app-villain-reactive-list [villains]="villains" [selectedVillain]='selected' [commands]="commands"></app-villain-reactive-list>
       </ng-template>
     </div>
   </div>
   <div class="detail-container">
-    <app-villain-detail *ngIf="selectedVillain" [villain]="selectedVillain" (unselect)="unselect()" (add)="add($event)"
-      (update)="update($event)">
-    </app-villain-detail>
+    <app-villain-reactive-detail *ngIf="selected" [villain]="selected" [commands]="commands">
+    </app-villain-reactive-detail>
   </div>
 </div>

--- a/src/app/villains/villains/villains-reactive.component.html
+++ b/src/app/villains/villains/villains-reactive.component.html
@@ -1,0 +1,22 @@
+<div class="control-panel">
+  <div class="button-panel">
+    <button mat-raised-button color="primary" type="button" (click)="getVillains()" matTooltip="Refresh the villains">Refresh</button>
+    <button mat-raised-button color="primary" type="button" (click)="enableAddMode()" *ngIf="!addingVillain && !selectedVillain"
+      matTooltip="Add a new villain">Add</button>
+  </div>
+</div>
+<div class="content-container">
+  <div class="list-container">
+    <div *ngIf="villains$ | async as villains">
+      <mat-spinner *ngIf="loading$ | async ;else villainList" mode="indeterminate" color="accent"></mat-spinner>
+      <ng-template #villainList>
+        <app-villain-list [villains]="villains" [selectedVillain]="selectedVillain" (deleted)="deleteVillain($event)" (selected)="onSelect($event)"></app-villain-list>
+      </ng-template>
+    </div>
+  </div>
+  <div class="detail-container">
+    <app-villain-detail *ngIf="selectedVillain" [villain]="selectedVillain" (unselect)="unselect()" (add)="add($event)"
+      (update)="update($event)">
+    </app-villain-detail>
+  </div>
+</div>

--- a/src/app/villains/villains/villains-reactive.component.ts
+++ b/src/app/villains/villains/villains-reactive.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
 
-import { Villain } from '../../core';
+import { MasterDetailCommands, Villain } from '../../core';
 import { VillainReactiveService } from '../villain-reactive.service';
 
 @Component({
@@ -10,8 +10,9 @@ import { VillainReactiveService } from '../villain-reactive.service';
   templateUrl: './villains-reactive.component.html',
   styleUrls: ['./villains.component.scss']
 })
-export class VillainsReactiveComponent implements OnInit {
-  selectedVillain: Villain;
+export class VillainsReactiveComponent implements MasterDetailCommands<Villain>, OnInit {
+  selected: Villain;
+  commands = this;
 
   villains$: Observable<Villain[]>;
   loading$: Observable<boolean>;
@@ -25,13 +26,14 @@ export class VillainsReactiveComponent implements OnInit {
     this.getVillains();
   }
 
-  clear() {
-    this.selectedVillain = null;
+  close() {
+    this.selected = null;
   }
 
   enableAddMode() {
-    this.selectedVillain = <any> {};
+    this.selected = <any> {};
   }
+
 
   getVillains() {
     this.villainService.getAll();
@@ -41,7 +43,7 @@ export class VillainsReactiveComponent implements OnInit {
     this.villainService.add(villain);
   }
 
-  deleteVillain(villain: Villain) {
+  delete(villain: Villain) {
     this.villainService.delete(villain.id);
   }
 
@@ -49,11 +51,11 @@ export class VillainsReactiveComponent implements OnInit {
     this.villainService.update(villain);
   }
 
-  onSelect(villain: Villain) {
-    this.selectedVillain = villain;
+  select(villain: Villain) {
+    this.selected = villain;
   }
 
   unselect() {
-    this.selectedVillain = null;
+    this.selected = null;
   }
 }

--- a/src/app/villains/villains/villains-reactive.component.ts
+++ b/src/app/villains/villains/villains-reactive.component.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit } from '@angular/core';
+
+import { Observable } from 'rxjs/Observable';
+
+import { Villain } from '../../core';
+import { VillainReactiveService } from '../villain-reactive.service';
+
+@Component({
+  selector: 'app-reactive-villains',
+  templateUrl: './villains-reactive.component.html',
+  styleUrls: ['./villains.component.scss']
+})
+export class VillainsReactiveComponent implements OnInit {
+  selectedVillain: Villain;
+
+  villains$: Observable<Villain[]>;
+  loading$: Observable<boolean>;
+
+  constructor(private villainService: VillainReactiveService) {
+    this.villains$ = villainService.villains$;
+    this.loading$ = villainService.loading$;
+  }
+
+  ngOnInit() {
+    this.getVillains();
+  }
+
+  clear() {
+    this.selectedVillain = null;
+  }
+
+  enableAddMode() {
+    this.selectedVillain = <any> {};
+  }
+
+  getVillains() {
+    this.villainService.getAll();
+  }
+
+  add(villain: Villain) {
+    this.villainService.add(villain);
+  }
+
+  deleteVillain(villain: Villain) {
+    this.villainService.delete(villain.id);
+  }
+
+  update(villain: Villain) {
+    this.villainService.update(villain);
+  }
+
+  onSelect(villain: Villain) {
+    this.selectedVillain = villain;
+  }
+
+  unselect() {
+    this.selectedVillain = null;
+  }
+}


### PR DESCRIPTION
FIRST COMMIT
Add reactive data service and reimplement Villains to use it (these versions of the components have the word "reactive").  In this commit, only needed to change the VillainsComponent from imperative to reactive style.

Slight change to adding mode logic. The addingVillain flag is unnecessary

SECOND COMMIT
Explores possibility of aggregating the outputs that presenters emit into a single commands input instead. The hope is that this simplifies the binding between parent container (master) and child presenters.

Deliberately did not include the Input side of the equation at this time. Could do that easily but that means removing the use of `AsyncPipe` and forcing presenters to subscribe or use `AsyncPipe` themselves.

I kind of want to try that so that the entire linkage between parent/child is in one object. But holding back on that idea until we discuss.