### PR TITLE
add step 8 to open the Redux DevTools to see the actions being disapt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ Run the app!
 ```bash
 ng serve -o
 ```
+### Step 8 - Verify the Redux actions are being dispatched 
+
+Navigate the application adding, updating, and removing heroes and villains. As you do this, notice the actions being dispatched in the  [Redux Devtools](https://github.com/zalmoxisus/redux-devtools-extension)
 
 ## What we did
 


### PR DESCRIPTION
Per our tweet thread, I mentioned that after going through the lab I was at first not convinced that Redux actions were being dispatched. I comfirmed that they were indeed being dispatched by opening up the Redux DevTools in Chrome and seeing them in the log.

From that came the idea, that we should add that verification as a final step of the lab.