### PR TITLE
Update README.md step 6 to add this.loading$ to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ We need to listen for the stream of hereos. Set your new `heroes$` property to t
 ```typescript
 constructor(private heroService: HeroService) {
   this.heroes$ = heroService.entities$;
+  this.loading$ = heroService.loading$;
 }
 ```
 


### PR DESCRIPTION
Step 6 of README.md instructed users to modify the loading property to be an Observable<boolean>, but then never referred to where to set it from. Updated the constructor to reflect that it comes from the service per documentation at [https://github.com/johnpapa/angular-ngrx-data/blob/master/docs/entity-services.md#create-a-custom-entitycollectionservice](https://github.com/johnpapa/angular-ngrx-data/blob/master/docs/entity-services.md#create-a-custom-entitycollectionservice)